### PR TITLE
Changed test key to at to avoid some conflicts

### DIFF
--- a/go-mode/test
+++ b/go-mode/test
@@ -1,6 +1,6 @@
 # -*- mode: snippet -*-
 # name: test
-# key: test
+# key: at
 # contributor : @atotto
 # --
 func Test$1(t *testing.T) {


### PR DESCRIPTION
Normally testing package is imported so when we type test, testing
package will be promoted.
